### PR TITLE
[POP-7251] Add entrypoint for using env vars to init dbt profile

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -23,7 +23,12 @@ else
     image_name="dbt-${adapter}"
 fi
 
+tag="ghcr.io/popsql/${image_name}:${version}"
+
 docker build \
     --build-arg REQUIREMENTS_FILE="${requirements_file}" \
-    --tag "ghcr.io/popsql/${image_name}:${version}" \
+    --build-arg DBT_VERSION="${version}" \
+    --tag "${tag}" \
     "${BASE_DIR}"
+
+echo "Successfully built image ${tag}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,19 @@
 
 if [ -n "${DBT_PROFILES}" ]; then
   echo "${DBT_PROFILES}" > /.dbt/profiles.yml
-elif [ -f ~/.dbt/profiles.yml ]; then
-  cp ~/.dbt/profiles.yml /.dbt/profiles.yml
-fi
-
-if [ -n "${AWS_CREDENTIALS}" ]; then
-  echo "${AWS_CREDENTIALS}" > /.dbt/aws_credentials
-elif [ -f ~/.aws/credentials ]; then
-  cp ~/.aws/credentials /.dbt/aws_credentials
-fi
-
-if [ -n "${BQ_KEYFILE}" ]; then
-  echo "${BQ_KEYFILE}" > /.dbt/bq_keyfile.json
+  if [ -n "${AWS_CREDENTIALS}" ]; then
+    echo "${AWS_CREDENTIALS}" > /.dbt/aws_credentials
+  fi
+  if [ -n "${BQ_KEYFILE}" ]; then
+    echo "${BQ_KEYFILE}" > /.dbt/bq_keyfile.json
+  fi
+else
+  if [ -f ~/.dbt/profiles.yml ]; then
+    cp ~/.dbt/profiles.yml /.dbt/profiles.yml
+  fi
+  if [ -f ~/.aws/credentials ]; then
+    cp ~/.aws/credentials /.dbt/aws_credentials
+  fi
 fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-if [ ! -z "${DBT_PROFILES}" ]; then
+if [ -n "${DBT_PROFILES}" ]; then
   echo "${DBT_PROFILES}" > /.dbt/profiles.yml
 elif [ -f ~/.dbt/profiles.yml ]; then
   cp ~/.dbt/profiles.yml /.dbt/profiles.yml
 fi
 
-if [ ! -z "${AWS_CREDENTIALS}" ]; then
+if [ -n "${AWS_CREDENTIALS}" ]; then
   echo "${AWS_CREDENTIALS}" > /.dbt/aws_credentials
 elif [ -f ~/.aws/credentials ]; then
   cp ~/.aws/credentials /.dbt/aws_credentials
 fi
 
-if [ ! -z "${BQ_KEYFILE}" ]; then
+if [ -n "${BQ_KEYFILE}" ]; then
   echo "${BQ_KEYFILE}" > /.dbt/bq_keyfile.json
 elif [ -f ~/.dbt/keyfile.json ]; then
   cp ~/.dbt/bq_keyfile.json /.dbt/bq_keyfile.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ ! -z "${DBT_PROFILES}" ]; then
+  echo "${DBT_PROFILES}" > /.dbt/profiles.yml
+elif [ -f ~/.dbt/profiles.yml ]; then
+  cp ~/.dbt/profiles.yml /.dbt/profiles.yml
+fi
+
+if [ ! -z "${AWS_CREDENTIALS}" ]; then
+  echo "${AWS_CREDENTIALS}" > /.dbt/aws_credentials
+elif [ -f ~/.aws/credentials ]; then
+  cp ~/.aws/credentials /.dbt/aws_credentials
+fi
+
+if [ ! -z "${BQ_KEYFILE}" ]; then
+  echo "${BQ_KEYFILE}" > /.dbt/bq_keyfile.json
+elif [ -f ~/.dbt/keyfile.json ]; then
+  cp ~/.dbt/bq_keyfile.json /.dbt/bq_keyfile.json
+fi
+
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,8 +14,6 @@ fi
 
 if [ -n "${BQ_KEYFILE}" ]; then
   echo "${BQ_KEYFILE}" > /.dbt/bq_keyfile.json
-elif [ -f ~/.dbt/keyfile.json ]; then
-  cp ~/.dbt/bq_keyfile.json /.dbt/bq_keyfile.json
 fi
 
 exec "$@"


### PR DESCRIPTION
PR modifies our images such that we now support the following three environment variables:
* `DBT_PROFILES` -> `/.dbt/profiles.yml`
* `AWS_CREDENTIALS` -> `/.dbt/aws_credentials`
* `BQ_KEYFILE` -> `/.dbt/bq_keyfile.json`

If the environment variable is not set, then we'll fallback to seeing if we can find the files as mounted (e.g. `/home/dbt/.dbt/profiles.yml`). We use the custom directory (with appropriate env vars set so dbt/aws look there) to host these files to allow easy migration from path based mounting to env vars without worrying about overwriting anything if for a period of time both are used.